### PR TITLE
Changed test program dependency and formated `dat2obj.py`.

### DIFF
--- a/dat2obj.md
+++ b/dat2obj.md
@@ -101,3 +101,5 @@ This program requires two command line arguments:
 All the `.dat` files found will be scanned, and corresponding `.oti` files created.
 If a `.dat` file do not have a *NAMES* section, no corresponding `.oti` file is generated!
 
+Note that the `pbPlist` Python module is required for `build_otis.py` to work.
+

--- a/dat2obj.py
+++ b/dat2obj.py
@@ -28,7 +28,7 @@ The first name will be the index 0 found in the .dat file, the second one
 index 1, and so on.
 """
 __authors__ = "(C) Giles Williams 2005 and Kaks 2008 / LaChal 2018."
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 import os
 import sys
@@ -157,8 +157,7 @@ def split_line(line):
     Returns a list of strings."""
     if ',' in line:
         return [a.strip() for a in line.split(',')]
-    else:
-        return line.split()
+    return line.split()
 
 
 def build_file_path(dir_name, file_name, ext):
@@ -185,9 +184,7 @@ def write_dump_file(dir_name, file_name, ext, datas):
                 for key, value in data.items():
                     if isinstance(value, OrderedDict):
                         value = dict(value)
-                    fd_out.write('"%s": %s\n' % (key, pprint.pformat(value,
-                                                                     indent=4)
-                                                                     ))
+                    fd_out.write('"%s": %s\n' % (key, pprint.pformat(value, indent=4)))
             else:
                 fd_out.write(pprint.pformat(data, indent=4))
 
@@ -535,7 +532,7 @@ def write_mtl(output_file_name, tex_map):
     :tex_map: dict: Texture map to find texture file names.
     """
 
-    def _build_entry(_tex_map, _idx="0"): 
+    def _build_entry(_tex_map, _idx="0"):
         """Builds a .mtl file entry.
         :_tex_map: dictionary: Map to look into.
         :_idx: string: The index to look for.
@@ -581,8 +578,9 @@ def main():
                 write_dump_file(file_dir_name, file_base_name, "sec",
                                 {"sections": sections})
 
-            if not len(sections):
-                _error("Nothing could be read from '%s'.\nIs this an Oolite .dat file?" % input_file_name)
+            if not sections:
+                _error("Nothing could be read from '%s'.\nIs this an Oolite .dat file?" \
+                       % input_file_name)
 
         # Magically call the 'check' functions
         for name in sections.keys():
@@ -614,7 +612,7 @@ def main():
         # used in 'TEXTURES'.
         if  sorted(tex_map.keys()) != sorted(tex_refs.get("named").keys()):
             tex_map = update_tex_map(tex_map,
-                    set(tex_refs["named"].keys()).difference(tex_map.keys()))
+                                     set(tex_refs["named"].keys()).difference(tex_map.keys()))
 
         if debug:
             write_dump_file(file_dir_name, file_base_name, "txm",

--- a/test/test_dat2obj.sh
+++ b/test/test_dat2obj.sh
@@ -29,8 +29,16 @@ function install_virtualenv () {
         wget -q --no-check-certificate -O .virtenv-inst "$VIRTUALENV_URL"
         tar xvf .virtenv-inst
         mv virtualenv* .virtualenv
-        python .virtualenv/virtualenv.py .venv --system-site-packages
+        echo "Creating virtual environment..."
+        # Badly, I experience uncompatibility issues if pip 9.0.3 is available
+        # on the system.
+        # Looks like sonmething between pip 9.0.1 and 9.0.3 changed in the API
+        # and make the virtual evironment fail if we want to use the system
+        # site-packages...
+        # python .virtualenv/virtualenv.py .venv --system-site-packages
+        python .virtualenv/virtualenv.py .venv
         chmod 755 .venv/bin/activate
+        echo "Done."
     fi
 }
 
@@ -41,9 +49,9 @@ function activate_venv () {
     echo "$VIRTUAL_ENV"
 }
 
-function install_openstep_parser () {
-    # Install the .plits Python parser in the virtual environment.
-    pip install openstep_parser
+function install_pbPlist () {
+    # Install the .plist Python parser in the virtual environment.
+    pip install pbPlist
 }
 
 function build_oti () {
@@ -175,7 +183,7 @@ install_virtualenv
 
 activate_venv
 
-install_openstep_parser
+install_pbPlist
 
 copy_files "oolite*.dat" "$OOLITE_MODELS_DIR" "$OUTPUT_LEFT" "$INPUT_DAT_FILES" "$IGNORE"
 


### PR DESCRIPTION
The test helper program `build_otis.py` now rely on `pbPlist` library instead of `openstep_parser`.
The test script `test_dat2obj.sh` has been updated to install `pbPlist` in the virtual environment.